### PR TITLE
Set the starting index of the current version to be 1 instead of 0 

### DIFF
--- a/src/Version.php
+++ b/src/Version.php
@@ -53,9 +53,16 @@ class Version
      */
     public function getCurrentVersion()
     {
-        $availableVersions = $this->getMigrationConfiguration()->getAvailableVersions();
         $currentVersion = $this->getMigrationConfiguration()->getCurrentVersion();
-        return (string)$availableVersions[$currentVersion];
+
+        // Migration version is 0, indicates no migration were ran
+        if (0 === $currentVersion || '0' === $currentVersion) {
+            return 0;
+        }
+
+        $availableVersions = $this->getMigrationConfiguration()->getAvailableVersions();
+
+        return (string)$availableVersions[$currentVersion - 1];
     }
 
     /**

--- a/test/VersionTest.php
+++ b/test/VersionTest.php
@@ -67,9 +67,11 @@ class VersionTest extends \PHPUnit_Framework_TestCase
 
         foreach (
             [
-                1 => '20171020101112',
-                0 => '20171020101111',
-                2 => '20171020101113',
+                2 => '20171020101112',
+                1 => '20171020101111',
+                0 => '0',
+                3 => '20171020101113',
+                '0' => '0',
             ] as $versionNumber => $version) {
 
             $this->setExpectedCurrentVersion($versionNumber);


### PR DESCRIPTION
as version 0 is an indicator of no migration has been ran